### PR TITLE
Changed name attributes to "transformation"

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,17 +48,17 @@
                     <br>
                     Select the transformation(s) applied to $f(x)$ to obtain $g(x)$
                 </p>
-                <input type="checkbox" id="horiz-shift" name="horiz-shift">
+                <input type="checkbox" id="horiz-shift" name="transformation">
                 <label for="horiz-shift">Horizontal Shift</label><br>
-                <input type="checkbox" id="vert-stretch-comp" name="vert-stretch-comp">
+                <input type="checkbox" id="vert-stretch-comp" name="transformation">
                 <label for="vert-stretch-comp">Vertical Stretch/Compression</label><br>
-                <input type="checkbox" id="horiz-refl" name="horiz-refl">
+                <input type="checkbox" id="horiz-refl" name="transformation">
                 <label for="horiz-refl">Horizontal Reflection (Reflection about the y-axis)</label><br>
-                <input type="checkbox" id="horiz-stretch-comp" name="horiz-stretch-comp">
+                <input type="checkbox" id="horiz-stretch-comp" name="transformation">
                 <label for="horiz-stretch-comp">Horizontal Stretch/Compression</label><br>
-                <input type="checkbox" id="vert-refl" name="vert-refl">
+                <input type="checkbox" id="vert-refl" name="transformation">
                 <label for="vert-refl">Vertical Reflection (Reflection about the x-axis)</label><br>
-                <input type="checkbox" id="vert-shift" name="vert-shift">
+                <input type="checkbox" id="vert-shift" name="transformation">
                 <label for="vert-shift">Vertical Shift</label><br>
             </div>
         </div>


### PR DESCRIPTION
The `name` attribute for the `<input>`'s in question 2 had different values, but they should be under the same name, which is now "transformation".